### PR TITLE
fix: update the base image to support Java 17

### DIFF
--- a/app-uploader/Dockerfile
+++ b/app-uploader/Dockerfile
@@ -1,4 +1,4 @@
-FROM androidsdk/android-31
+FROM runmymind/docker-android-sdk:ubuntu-standalone-sha-eaf5982
 
 ARG sauce_username
 ARG sauce_access_key


### PR DESCRIPTION

The uploader run fail with the latest version of the Opbeans because it needs Java 17. This PR change the Base Docker image to the original that already support Java 17.